### PR TITLE
Add Compatibility with Docker Compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  truenas-gotify-adapter:
+    image: ghcr.io/ztube/truenas-gotify-adapter:main
+    container_name: truenas-gotify-adapter
+    restart: unless-stopped
+    environment:
+      GOTIFY_URL: https://push.example.com
+      GOTIFY_TOKEN: gotify_token
+    ports:
+      - 31662:31662

--- a/truenas-gotify.py
+++ b/truenas-gotify.py
@@ -11,7 +11,7 @@ GOTIFY_BASEURL = os.environ.get("GOTIFY_URL")
 # Example: cGVla2Fib29v
 GOTIFY_TOKEN = os.environ.get("GOTIFY_TOKEN")
 
-LISTEN_HOST = "127.0.0.1"
+LISTEN_HOST = "0.0.0.0"
 PORT = 31662
 
 


### PR DESCRIPTION
First thanks @ZTube for posting this adapter as it is awesome! My use case was a bit different than yours in that I am running all of my apps in jlmkr jail instead of in the TrueNAS Apps. I didn't want to run the entire Kubernetes subsystem in the meantime just to get Gotify Notifications. I have submitted this pull request with two changes: Adding a compose.yaml and change the listening host in the python script from the loopback to 0.0.0.0. The listening port change may be slightly less secure but I don't think it represents a major issue but I am open to other suggestions. 

I hope this is well received as it is my first pull request. 